### PR TITLE
Improve no-transition-all rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.1. (11.08.2021)
+
+Fixed `no-transition-all` rule. Now it may check implicit `all`, e.g. `transition: 2s;`.
+
+
 ## 2.0.0 (23.10.2020)
 
 Breaking change: Added Stylelint as a peer dep.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@funboxteam/stylelint-rules",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funboxteam/stylelint-rules",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A collection of SCSS rules missing in stylelint-scss",
   "author": "Natalia Andreychenko <natandreychenko@gmail.com> (https://github.com/natrey)",
   "license": "MIT",

--- a/src/rules/no-transition-all/__tests__/index.js
+++ b/src/rules/no-transition-all/__tests__/index.js
@@ -71,5 +71,15 @@ testRule(rule, {
       messages: messages.rejected,
       description: 'One transition property, all value is used.',
     },
+    {
+      code: `
+      .test-implicit-all-fail {
+        transition: 2s ease-in, width 7s;
+      }
+     `,
+      line: 3,
+      messages: messages.expected,
+      description: 'One explicit property and one implicit all value is used.',
+    },
   ],
 });

--- a/src/rules/no-transition-all/index.js
+++ b/src/rules/no-transition-all/index.js
@@ -4,8 +4,23 @@ const namespace = require('../../utils/namespace');
 const ruleName = namespace('no-transition-all');
 
 const messages = utils.ruleMessages(ruleName, {
-  rejected: 'The keyword "all" should not be used with the "transition" property',
+  rejected: 'The keyword "all" should not be used with the "transition" property explicitly or implicitly',
 });
+
+const isImplicitTransitionAll = (shorthandValue) => {
+  const valueParts = shorthandValue.split(',').map(value => value.trim().split(' '));
+
+  const TIMING_FUNCTION_REGEXP = /^(ease|linear|step|cubic-bezier)/;
+  const PROPERTY_REGEXP = /^[a-z]+(-[a-z]+)?$/;
+
+  for (let i = 0; i < valueParts.length; i += 1) {
+    if (!valueParts[i].some(value => PROPERTY_REGEXP.test(value) && !TIMING_FUNCTION_REGEXP.test(value))) {
+      return true;
+    }
+  }
+
+  return false;
+};
 
 const rule = actual => (root, result) => {
   const validOptions = utils.validateOptions(result, ruleName, { actual });
@@ -15,9 +30,10 @@ const rule = actual => (root, result) => {
   }
 
   root.walkDecls(/transition/, (decl) => {
-    const valueArr = decl.value.split(' ');
+    const isExplicitAll = () => decl.value.split(',').flatMap(val => val.trim().split(' ')).some(val => val === 'all');
+    const isImplicitAll = () => decl.prop === 'transition' && isImplicitTransitionAll(decl.value);
 
-    if (valueArr.find(val => val === 'all')) {
+    if (isExplicitAll() || isImplicitAll()) {
       utils.report({
         message: messages.rejected,
         node: decl,


### PR DESCRIPTION
This PR adds support for implicit 'all' in the transition shorthand property, e.g. `transition: 2s;`.